### PR TITLE
Add Finnhub news ingestion and cross-encoder evaluation on news corpus

### DIFF
--- a/CROSS_ENCODER_EVAL_RESULTS.md
+++ b/CROSS_ENCODER_EVAL_RESULTS.md
@@ -149,6 +149,84 @@ The better conclusion is:
 
 - "cross-encoders were not a clear win on the current SEC-only corpus, but they may become much more valuable once the retrieval problem becomes noisier and more heterogeneous."
 
+---
+
+## Evaluation 2: Finnhub News Corpus (`news`)
+
+### Setup
+
+- Corpus: `news` (Finnhub news articles for NVDA, ingested via Pinecone)
+- Vector store: Pinecone + `text-embedding-3-small`
+- Reranker: `BAAI/bge-reranker-base`
+- Retriever candidates: top `10`
+- Final context size: top `3`
+- Evaluation set: [evals/news_retrieval_eval.json](/Users/rchadha/Documents/projects/p/rag-application/evals/news_retrieval_eval.json)
+- Questions evaluated: `8`
+
+### Results
+
+#### Baseline: dense retrieval only
+
+- `Hit@1 = 1.000`
+- `Hit@3 = 1.000`
+- `MRR = 1.000`
+
+#### Cross-encoder: `BAAI/bge-reranker-base`
+
+- `Hit@1 = 0.625`
+- `Hit@3 = 0.875`
+- `MRR = 0.750`
+
+Outcome:
+
+- dense baseline was **perfect** on all 8 questions
+- reranker degraded performance across every metric
+- stronger regression than observed on the SEC corpus
+
+### What Got Worse
+
+The reranker failed on 3 of 8 questions:
+
+**Q: "What is the demand outlook for NVIDIA AI data center products?"**
+- Baseline: expected source at rank 1 (vector score 0.849)
+- Reranked: non-expected article pushed to rank 1 (rerank score 0.944), expected source dropped to rank 2
+
+**Q: "How is NVIDIA competing against AMD and Intel?"**
+- Baseline: expected source at rank 1
+- Reranked: a closely-related but non-expected article pushed to rank 1 (rerank scores nearly identical at 0.00073 vs 0.00070 — effectively random at that scale)
+
+**Q: "What has Jensen Huang announced recently?"**
+- Baseline: expected sources at ranks 1, 2, 3
+- Reranked: all three expected sources evicted from top 3 entirely — completely different articles promoted (rerank scores 0.986, 0.895, 0.427)
+- This is the worst single-question regression observed across both evaluations
+
+### Why the Regression is Worse on News
+
+The SEC corpus is dense, structured, and long-form. Each chunk carries enough signal for the reranker to make confident relevance judgements.
+
+News articles are short headlines and summaries. The reranker saw short, overlapping text — many articles about NVDA are topically similar — making rerank scores noisy and unreliable. The dense retrieval model (`text-embedding-3-small`) had already done the hard work well; the reranker introduced noise on top.
+
+The "Jensen Huang" failure is a good example: the reranker promoted articles with high surface relevance to the query but that were not the specific sources the dense retriever had correctly identified.
+
+### Combined Conclusion Across Both Corpora
+
+| Corpus | Baseline Hit@1 | Reranked Hit@1 | Verdict |
+|--------|---------------|----------------|---------|
+| SEC filings | 0.875 | 0.750 | reranker hurt top-1 |
+| Finnhub news | **1.000** | **0.625** | reranker hurt top-1 significantly |
+
+Across both structured (SEC) and unstructured (news) corpora, `BAAI/bge-reranker-base` did not improve retrieval and in both cases reduced top-1 precision. The degradation was more severe on the news corpus, where the dense baseline was already perfect.
+
+This is not evidence that cross-encoders are universally ineffective. The likely causes here are:
+
+- Short document length in the news corpus reduces reranker signal quality
+- High topical overlap across news articles makes fine-grained reranking harder
+- `BAAI/bge-reranker-base` is a general-purpose model not tuned for financial news
+
+A domain-fine-tuned reranker or a larger model may perform differently. But the current evidence across two corpora is consistent: **the dense baseline should remain the default**.
+
+---
+
 ## Commands Used
 
 Baseline query:

--- a/evals/cross_encoder_results_news.json
+++ b/evals/cross_encoder_results_news.json
@@ -1,0 +1,501 @@
+{
+  "dataset": "news",
+  "embedding_model": "text-embedding-3-small",
+  "cross_encoder_model": "BAAI/bge-reranker-base",
+  "baseline_summary": {
+    "questions": 8,
+    "hit_at_1": 1.0,
+    "hit_at_3": 1.0,
+    "mrr": 1.0
+  },
+  "reranked_summary": {
+    "questions": 8,
+    "hit_at_1": 0.625,
+    "hit_at_3": 0.875,
+    "mrr": 0.75
+  },
+  "baseline": [
+    {
+      "question": "What is the latest news about NVIDIA chip sales in China?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444628",
+        "finnhub/NVDA/139445241",
+        "finnhub/NVDA/139445240"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139445241",
+          "vector_score": 0.8662519155,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139444628",
+          "vector_score": 0.8441471755000001,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139445240",
+          "vector_score": 0.8368538915,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What are NVIDIA's latest earnings and revenue results?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444639",
+        "finnhub/NVDA/139438378",
+        "finnhub/NVDA/139433839"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139444639",
+          "vector_score": 0.818906307,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139438378",
+          "vector_score": 0.806067,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139433839",
+          "vector_score": 0.7960238454999999,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What are analysts saying about NVIDIA stock price target?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139433145",
+        "finnhub/NVDA/139434852",
+        "finnhub/NVDA/139437751"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139433145",
+          "vector_score": 0.8433369399999999,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139437751",
+          "vector_score": 0.8390965165,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139434852",
+          "vector_score": 0.836284697,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What is the demand outlook for NVIDIA AI data center products?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139443603",
+        "finnhub/NVDA/139435876",
+        "finnhub/NVDA/139434437"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139443603",
+          "vector_score": 0.848703861,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139439107",
+          "vector_score": 0.8305311205,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139434437",
+          "vector_score": 0.8195428849999999,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What export restrictions or regulations affect NVIDIA?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444628",
+        "finnhub/NVDA/139445241",
+        "finnhub/NVDA/139445237"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139444628",
+          "vector_score": 0.783143252,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139445241",
+          "vector_score": 0.76954782,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139445237",
+          "vector_score": 0.756007731,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "How is NVIDIA competing against AMD and Intel?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139437137",
+        "finnhub/NVDA/139443597",
+        "finnhub/NVDA/139433844"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139437137",
+          "vector_score": 0.7862501145,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139443597",
+          "vector_score": 0.7850790000000001,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139437320",
+          "vector_score": 0.784477234,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What is the latest news about NVIDIA Blackwell GPU production?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139437316",
+        "finnhub/NVDA/139433839",
+        "finnhub/NVDA/139443587"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139437316",
+          "vector_score": 0.7872469424999999,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139433839",
+          "vector_score": 0.78565374,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139443587",
+          "vector_score": 0.7836095395,
+          "rerank_score": null
+        }
+      ]
+    },
+    {
+      "question": "What has Jensen Huang announced recently?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444639",
+        "finnhub/NVDA/139438380",
+        "finnhub/NVDA/139433844"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139438380",
+          "vector_score": 0.818867892,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139444639",
+          "vector_score": 0.816222161,
+          "rerank_score": null
+        },
+        {
+          "source": "finnhub/NVDA/139433844",
+          "vector_score": 0.803196758,
+          "rerank_score": null
+        }
+      ]
+    }
+  ],
+  "reranked": [
+    {
+      "question": "What is the latest news about NVIDIA chip sales in China?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444628",
+        "finnhub/NVDA/139445241",
+        "finnhub/NVDA/139445240"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139445241",
+          "vector_score": 0.8662519155,
+          "rerank_score": 0.9654710292816162
+        },
+        {
+          "source": "finnhub/NVDA/139445240",
+          "vector_score": 0.8368538915,
+          "rerank_score": 0.9087990522384644
+        },
+        {
+          "source": "finnhub/NVDA/139445238",
+          "vector_score": 0.8339953124999999,
+          "rerank_score": 0.5630956888198853
+        }
+      ]
+    },
+    {
+      "question": "What are NVIDIA's latest earnings and revenue results?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444639",
+        "finnhub/NVDA/139438378",
+        "finnhub/NVDA/139433839"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139433839",
+          "vector_score": 0.7960247995,
+          "rerank_score": 0.5455400347709656
+        },
+        {
+          "source": "finnhub/NVDA/139438378",
+          "vector_score": 0.8059487345,
+          "rerank_score": 0.31139838695526123
+        },
+        {
+          "source": "finnhub/NVDA/139445250",
+          "vector_score": 0.779457122,
+          "rerank_score": 0.019239045679569244
+        }
+      ]
+    },
+    {
+      "question": "What are analysts saying about NVIDIA stock price target?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139433145",
+        "finnhub/NVDA/139434852",
+        "finnhub/NVDA/139437751"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139433145",
+          "vector_score": 0.8433369399999999,
+          "rerank_score": 0.9950768351554871
+        },
+        {
+          "source": "finnhub/NVDA/139437313",
+          "vector_score": 0.8219183385,
+          "rerank_score": 0.9871297478675842
+        },
+        {
+          "source": "finnhub/NVDA/139437324",
+          "vector_score": 0.8325245975,
+          "rerank_score": 0.984597384929657
+        }
+      ]
+    },
+    {
+      "question": "What is the demand outlook for NVIDIA AI data center products?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139443603",
+        "finnhub/NVDA/139435876",
+        "finnhub/NVDA/139434437"
+      ],
+      "rank": 2,
+      "hit_at_1": 0,
+      "hit_at_3": 1,
+      "mrr": 0.5,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139439107",
+          "vector_score": 0.8306635,
+          "rerank_score": 0.9444132447242737
+        },
+        {
+          "source": "finnhub/NVDA/139434437",
+          "vector_score": 0.8196794095,
+          "rerank_score": 0.7544788122177124
+        },
+        {
+          "source": "finnhub/NVDA/139443603",
+          "vector_score": 0.8487688305000001,
+          "rerank_score": 0.16940109431743622
+        }
+      ]
+    },
+    {
+      "question": "What export restrictions or regulations affect NVIDIA?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444628",
+        "finnhub/NVDA/139445241",
+        "finnhub/NVDA/139445237"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139444628",
+          "vector_score": 0.7830667495,
+          "rerank_score": 0.4135435223579407
+        },
+        {
+          "source": "finnhub/NVDA/139445240",
+          "vector_score": 0.7491116225,
+          "rerank_score": 0.012993120588362217
+        },
+        {
+          "source": "finnhub/NVDA/139437319",
+          "vector_score": 0.740816593,
+          "rerank_score": 0.0037219610530883074
+        }
+      ]
+    },
+    {
+      "question": "How is NVIDIA competing against AMD and Intel?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139437137",
+        "finnhub/NVDA/139443597",
+        "finnhub/NVDA/139433844"
+      ],
+      "rank": 2,
+      "hit_at_1": 0,
+      "hit_at_3": 1,
+      "mrr": 0.5,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139437320",
+          "vector_score": 0.7845630645,
+          "rerank_score": 0.0007270606001839042
+        },
+        {
+          "source": "finnhub/NVDA/139437137",
+          "vector_score": 0.7863598465,
+          "rerank_score": 0.0007004841463640332
+        },
+        {
+          "source": "finnhub/NVDA/139433844",
+          "vector_score": 0.776022166,
+          "rerank_score": 0.0006673417519778013
+        }
+      ]
+    },
+    {
+      "question": "What is the latest news about NVIDIA Blackwell GPU production?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139437316",
+        "finnhub/NVDA/139433839",
+        "finnhub/NVDA/139443587"
+      ],
+      "rank": 1,
+      "hit_at_1": 1,
+      "hit_at_3": 1,
+      "mrr": 1.0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139443587",
+          "vector_score": 0.7836095395,
+          "rerank_score": 0.03607731685042381
+        },
+        {
+          "source": "finnhub/NVDA/139433839",
+          "vector_score": 0.78565374,
+          "rerank_score": 0.03454681485891342
+        },
+        {
+          "source": "finnhub/NVDA/139437316",
+          "vector_score": 0.7872469424999999,
+          "rerank_score": 0.02005670592188835
+        }
+      ]
+    },
+    {
+      "question": "What has Jensen Huang announced recently?",
+      "dataset": "news",
+      "expected_sources": [
+        "finnhub/NVDA/139444639",
+        "finnhub/NVDA/139438380",
+        "finnhub/NVDA/139433844"
+      ],
+      "rank": null,
+      "hit_at_1": 0,
+      "hit_at_3": 0,
+      "mrr": 0,
+      "results": [
+        {
+          "source": "finnhub/NVDA/139435876",
+          "vector_score": 0.791937858,
+          "rerank_score": 0.9856729507446289
+        },
+        {
+          "source": "finnhub/NVDA/139435924",
+          "vector_score": 0.7803755,
+          "rerank_score": 0.8954943418502808
+        },
+        {
+          "source": "finnhub/NVDA/139445241",
+          "vector_score": 0.7808170615000001,
+          "rerank_score": 0.42717865109443665
+        }
+      ]
+    }
+  ]
+}

--- a/evals/news_retrieval_eval.json
+++ b/evals/news_retrieval_eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "question": "What is the latest news about NVIDIA chip sales in China?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139444628",
+      "finnhub/NVDA/139445241",
+      "finnhub/NVDA/139445240"
+    ]
+  },
+  {
+    "question": "What are NVIDIA's latest earnings and revenue results?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139444639",
+      "finnhub/NVDA/139438378",
+      "finnhub/NVDA/139433839"
+    ]
+  },
+  {
+    "question": "What are analysts saying about NVIDIA stock price target?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139433145",
+      "finnhub/NVDA/139434852",
+      "finnhub/NVDA/139437751"
+    ]
+  },
+  {
+    "question": "What is the demand outlook for NVIDIA AI data center products?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139443603",
+      "finnhub/NVDA/139435876",
+      "finnhub/NVDA/139434437"
+    ]
+  },
+  {
+    "question": "What export restrictions or regulations affect NVIDIA?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139444628",
+      "finnhub/NVDA/139445241",
+      "finnhub/NVDA/139445237"
+    ]
+  },
+  {
+    "question": "How is NVIDIA competing against AMD and Intel?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139437137",
+      "finnhub/NVDA/139443597",
+      "finnhub/NVDA/139433844"
+    ]
+  },
+  {
+    "question": "What is the latest news about NVIDIA Blackwell GPU production?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139437316",
+      "finnhub/NVDA/139433839",
+      "finnhub/NVDA/139443587"
+    ]
+  },
+  {
+    "question": "What has Jensen Huang announced recently?",
+    "dataset": "news",
+    "expected_sources": [
+      "finnhub/NVDA/139444639",
+      "finnhub/NVDA/139438380",
+      "finnhub/NVDA/139433844"
+    ]
+  }
+]

--- a/evaluate_cross_encoder.py
+++ b/evaluate_cross_encoder.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 from pathlib import Path
 
 from retrieval import CROSS_ENCODER_MODEL_NAME, EMBEDDING_MODEL_NAME, get_top_results
 
-EVAL_SET_PATH = Path("evals/sec_retrieval_eval.json")
+EVAL_SETS = {
+    "sec": Path("evals/sec_retrieval_eval.json"),
+    "news": Path("evals/news_retrieval_eval.json"),
+}
 RESULTS_PATH = Path("evals/cross_encoder_results.json")
 
 
@@ -67,11 +71,19 @@ def summarize(items: list[dict]):
 
 
 def main():
-    eval_items = json.loads(EVAL_SET_PATH.read_text(encoding="utf-8"))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", choices=["sec", "news"], default="sec")
+    args = parser.parse_args()
+
+    eval_set_path = EVAL_SETS[args.dataset]
+    results_path = Path(f"evals/cross_encoder_results_{args.dataset}.json")
+
+    eval_items = json.loads(eval_set_path.read_text(encoding="utf-8"))
     baseline = score_run(eval_items, use_reranker=False)
     reranked = score_run(eval_items, use_reranker=True)
 
     payload = {
+        "dataset": args.dataset,
         "embedding_model": EMBEDDING_MODEL_NAME,
         "cross_encoder_model": CROSS_ENCODER_MODEL_NAME,
         "baseline_summary": summarize(baseline),
@@ -80,8 +92,11 @@ def main():
         "reranked": reranked,
     }
 
-    RESULTS_PATH.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    results_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\nDataset: {args.dataset}")
+    print("Baseline:")
     print(json.dumps(payload["baseline_summary"], indent=2))
+    print("Reranked:")
     print(json.dumps(payload["reranked_summary"], indent=2))
 
 


### PR DESCRIPTION
## Summary

- **Switch vector store to Pinecone** — `retrieval.py` and `create_database.py` migrated from Chroma to Pinecone with support for `sec`, `earnings`, `social`, and `news` namespaces
- **Add Finnhub news ingestion** — new `ingest_social.py` script fetches daily news articles for any ticker, scores sentiment with VADER, and upserts to Pinecone with deduplication (skips embedding for already-indexed articles)
- **Fix `query_data.py`** — updated `query_database` signature to match `app.py`, added `social` and `news` as valid dataset choices
- **Cross-encoder evaluation on news corpus** — ran `BAAI/bge-reranker-base` against 8 NVDA news questions; dense baseline was perfect (Hit@1=1.0), reranker degraded to Hit@1=0.625
- **Update eval framework** — `evaluate_cross_encoder.py` now supports `--dataset sec|news` flag
- **Update `CROSS_ENCODER_EVAL_RESULTS.md`** — added full news corpus findings and combined summary table across SEC and news corpora

## Test plan

- [ ] Run `python ingest_social.py --ticker NVDA --company "NVIDIA"` and confirm articles upserted to Pinecone `news` namespace
- [ ] Re-run to confirm duplicate articles are skipped (no OpenAI embedding calls for existing IDs)
- [ ] Run `python query_data.py "What is the latest news about NVIDIA?" --dataset news` and confirm relevant results
- [ ] Run `python evaluate_cross_encoder.py --dataset news` and confirm baseline Hit@1=1.0, reranked Hit@1=0.625

🤖 Generated with [Claude Code](https://claude.com/claude-code)