### PR TITLE
Migrate from ECS Fargate to AWS Lambda + API Gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,15 @@
-# Use Python 3.13 slim image for smaller size
-FROM python:3.13-slim
-
-# Set working directory
-WORKDIR /app
-
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy requirements first for better layer caching
-COPY requirements.txt .
+# AWS Lambda container image
+FROM public.ecr.aws/lambda/python:3.13
 
 # Install Python dependencies
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# NLTK data will be downloaded at runtime on first use instead of during build
-# This avoids cross-platform build issues
+# Download NLTK data
+RUN python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 
 # Copy application code
 COPY *.py ./
 
-# Create a non-root user for security
-RUN useradd -m -u 1000 appuser && \
-    chown -R appuser:appuser /app
-USER appuser
-
-# Expose port
-EXPOSE 3001
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:3001/health', timeout=5)" || exit 1
-
-# Run the application with gunicorn for production
-CMD ["python", "app.py"]
+# Lambda handler
+CMD ["lambda_handler.handler"]

--- a/app.py
+++ b/app.py
@@ -7,38 +7,44 @@ import boto3
 from botocore.exceptions import ClientError
 
 
-def _load_secret(secret_name: str, env_key: str) -> None:
-    """Fetch a secret from AWS Secrets Manager and inject into os.environ."""
-    if os.environ.get(env_key):
-        return  # already set (e.g. local dev via .env)
-    try:
-        client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
-        response = client.get_secret_value(SecretId=secret_name)
-        secret = response.get("SecretString", "")
-        # Secrets Manager may return JSON or a plain string
+_secrets_loaded = False
+
+
+def _load_secrets() -> None:
+    """Fetch secrets from AWS Secrets Manager on first request. No-op if already in environment."""
+    global _secrets_loaded
+    if _secrets_loaded:
+        return
+
+    def _fetch(secret_name: str, env_key: str) -> None:
+        if os.environ.get(env_key):
+            return
         try:
-            os.environ[env_key] = json.loads(secret)
-        except (json.JSONDecodeError, TypeError):
-            os.environ[env_key] = secret
-    except ClientError as e:
-        print(f"Warning: could not fetch secret {secret_name}: {e}")
+            client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+            response = client.get_secret_value(SecretId=secret_name)
+            secret = response.get("SecretString", "")
+            try:
+                os.environ[env_key] = json.loads(secret)
+            except (json.JSONDecodeError, TypeError):
+                os.environ[env_key] = secret
+        except ClientError as e:
+            print(f"Warning: could not fetch secret {secret_name}: {e}")
 
-
-# Bootstrap secrets on cold start (no-op if already in environment)
-_PROJECT = os.environ.get("PROJECT_NAME", "rag-application")
-_load_secret(f"{_PROJECT}/openai-api-key", "OPENAI_API_KEY")
-_load_secret(f"{_PROJECT}/pinecone-api-key", "PINECONE_API_KEY")
+    project = os.environ.get("PROJECT_NAME", "rag-application")
+    _fetch(f"{project}/openai-api-key", "OPENAI_API_KEY")
+    _fetch(f"{project}/pinecone-api-key", "PINECONE_API_KEY")
+    _secrets_loaded = True
 
 app = Flask(__name__)
 CORS(app) # Enable CORS for all routes
 
 @app.route('/health', methods=['GET'])
 def health():
-    """Health check endpoint for ECS/ALB"""
     return jsonify({'status': 'healthy'}), 200
 
 @app.route('/query', methods=['POST'])
 def query():
+    _load_secrets()
     data = request.get_json()
     print(f"Received data: {data}")
     if not data or 'query' not in data:

--- a/app.py
+++ b/app.py
@@ -2,6 +2,32 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from query_data import query_database
 import os
+import json
+import boto3
+from botocore.exceptions import ClientError
+
+
+def _load_secret(secret_name: str, env_key: str) -> None:
+    """Fetch a secret from AWS Secrets Manager and inject into os.environ."""
+    if os.environ.get(env_key):
+        return  # already set (e.g. local dev via .env)
+    try:
+        client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+        response = client.get_secret_value(SecretId=secret_name)
+        secret = response.get("SecretString", "")
+        # Secrets Manager may return JSON or a plain string
+        try:
+            os.environ[env_key] = json.loads(secret)
+        except (json.JSONDecodeError, TypeError):
+            os.environ[env_key] = secret
+    except ClientError as e:
+        print(f"Warning: could not fetch secret {secret_name}: {e}")
+
+
+# Bootstrap secrets on cold start (no-op if already in environment)
+_PROJECT = os.environ.get("PROJECT_NAME", "rag-application")
+_load_secret(f"{_PROJECT}/openai-api-key", "OPENAI_API_KEY")
+_load_secret(f"{_PROJECT}/pinecone-api-key", "PINECONE_API_KEY")
 
 app = Flask(__name__)
 CORS(app) # Enable CORS for all routes

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,10 +1,8 @@
 """
-AWS Lambda handler — wraps the Flask app using aws-wsgi.
+AWS Lambda handler — wraps the Flask app using apig-wsgi.
 Lambda receives API Gateway events and forwards them to the Flask app.
 """
-import awsgi
+from apig_wsgi import make_lambda_handler
 from app import app
 
-
-def handler(event, context):
-    return awsgi.response(app, event, context)
+handler = make_lambda_handler(app)

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,0 +1,10 @@
+"""
+AWS Lambda handler — wraps the Flask app using aws-wsgi.
+Lambda receives API Gateway events and forwards them to the Flask app.
+"""
+import awsgi
+from app import app
+
+
+def handler(event, context):
+    return awsgi.response(app, event, context)

--- a/requirements-ingest.txt
+++ b/requirements-ingest.txt
@@ -1,0 +1,11 @@
+# Dependencies for local data ingestion scripts (create_database.py, ingest_social.py)
+# Not needed for the Flask API / Lambda runtime
+-r requirements.txt
+unstructured # Document loading
+unstructured[md] # For markdown support
+scikit-learn
+matplotlib
+beautifulsoup4
+docx2txt
+vaderSentiment # Sentiment analysis
+sentence-transformers # Cross-encoder reranking (optional, for evaluate_cross_encoder.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,22 +3,14 @@ langchain
 langsmith
 langchain-community
 langchain-openai # For embeddings
-unstructured # Document loading
-unstructured[md] # For markdown support
-# onnxruntime==1.17.1 # chromadb dependency: on Mac use `conda install onnxruntime -c conda-forge`
-# For Windows users, install Microsoft Visual C++ Build Tools first
-# install onnxruntime before installing `chromadb`
 langchain-pinecone # Vector storage
 langchain-text-splitters
 pinecone
 openai # For embeddings
-tiktoken  # For embeddings 
+tiktoken  # For embeddings
 nltk # For embeddings
 flask
 flask-cors
-scikit-learn
-matplotlib
 requests
-beautifulsoup4
-docx2txt
-vaderSentiment # Sentiment analysis for social media
+awsgi # AWS API Gateway to WSGI bridge for Lambda
+boto3 # AWS SDK (pre-installed in Lambda, needed locally)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ nltk # For embeddings
 flask
 flask-cors
 requests
-awsgi # AWS API Gateway to WSGI bridge for Lambda
+apig-wsgi # AWS API Gateway to WSGI adapter for Lambda
 boto3 # AWS SDK (pre-installed in Lambda, needed locally)

--- a/retrieval.py
+++ b/retrieval.py
@@ -5,7 +5,12 @@ from typing import Any
 from dotenv import load_dotenv
 from langchain_pinecone import PineconeVectorStore
 from langchain_openai import OpenAIEmbeddings
-from sentence_transformers import CrossEncoder
+
+try:
+    from sentence_transformers import CrossEncoder
+    _RERANKER_AVAILABLE = True
+except ImportError:
+    _RERANKER_AVAILABLE = False
 
 load_dotenv()
 
@@ -40,8 +45,10 @@ def _get_embedding_function() -> OpenAIEmbeddings:
     return OpenAIEmbeddings(model=EMBEDDING_MODEL_NAME)
 
 
-def _get_reranker() -> CrossEncoder:
+def _get_reranker():
     global _reranker
+    if not _RERANKER_AVAILABLE:
+        raise ImportError("sentence-transformers is not installed. Run: pip install sentence-transformers")
     if _reranker is None:
         _reranker = CrossEncoder(CROSS_ENCODER_MODEL_NAME)
     return _reranker

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -167,8 +167,8 @@ resource "aws_lambda_function" "app" {
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.app.repository_url}:latest"
   role          = aws_iam_role.lambda_exec.arn
-  timeout       = 30
-  memory_size   = 512
+  timeout       = 120
+  memory_size   = 1024
 
   environment {
     variables = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,137 +25,6 @@ provider "aws" {
 # Data sources
 data "aws_caller_identity" "current" {}
 
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-# VPC and Networking
-resource "aws_vpc" "main" {
-  cidr_block           = var.vpc_cidr
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = {
-    Name        = "${var.project_name}-vpc"
-    Environment = var.environment
-  }
-}
-
-resource "aws_subnet" "public" {
-  count                   = 2
-  vpc_id                  = aws_vpc.main.id
-  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name        = "${var.project_name}-public-subnet-${count.index + 1}"
-    Environment = var.environment
-  }
-}
-
-resource "aws_internet_gateway" "main" {
-  vpc_id = aws_vpc.main.id
-
-  tags = {
-    Name        = "${var.project_name}-igw"
-    Environment = var.environment
-  }
-}
-
-resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.main.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.main.id
-  }
-
-  tags = {
-    Name        = "${var.project_name}-public-rt"
-    Environment = var.environment
-  }
-}
-
-resource "aws_route_table_association" "public" {
-  count          = 2
-  subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public.id
-}
-
-# Security Groups
-
-# ALB Security Group - uncomment when re-enabling ALB
-# resource "aws_security_group" "alb" {
-#   name        = "${var.project_name}-alb-sg"
-#   description = "Security group for Application Load Balancer"
-#   vpc_id      = aws_vpc.main.id
-#
-#   ingress {
-#     from_port   = 80
-#     to_port     = 80
-#     protocol    = "tcp"
-#     cidr_blocks = ["0.0.0.0/0"]
-#     description = "Allow HTTP"
-#   }
-#
-#   ingress {
-#     from_port   = 443
-#     to_port     = 443
-#     protocol    = "tcp"
-#     cidr_blocks = ["0.0.0.0/0"]
-#     description = "Allow HTTPS"
-#   }
-#
-#   egress {
-#     from_port   = 0
-#     to_port     = 0
-#     protocol    = "-1"
-#     cidr_blocks = ["0.0.0.0/0"]
-#     description = "Allow all outbound"
-#   }
-#
-#   tags = {
-#     Name        = "${var.project_name}-alb-sg"
-#     Environment = var.environment
-#   }
-# }
-
-resource "aws_security_group" "ecs_tasks" {
-  name        = "${var.project_name}-ecs-tasks-sg"
-  description = "Security group for ECS tasks"
-  vpc_id      = aws_vpc.main.id
-
-  # Direct internet access (no ALB). When re-enabling ALB, replace this with:
-  # ingress {
-  #   from_port       = var.container_port
-  #   to_port         = var.container_port
-  #   protocol        = "tcp"
-  #   security_groups = [aws_security_group.alb.id]
-  #   description     = "Allow traffic from ALB"
-  # }
-  ingress {
-    from_port   = var.container_port
-    to_port     = var.container_port
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow direct internet access"
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow all outbound"
-  }
-
-  tags = {
-    Name        = "${var.project_name}-ecs-tasks-sg"
-    Environment = var.environment
-  }
-}
-
 # ECR Repository
 resource "aws_ecr_repository" "app" {
   name                 = var.project_name
@@ -220,81 +89,6 @@ resource "aws_secretsmanager_secret" "pinecone_api_key" {
 # Note: The secret value must be set manually or via GitHub Actions
 # aws secretsmanager put-secret-value --secret-id <secret-name> --secret-string "your-key"
 
-# CloudWatch Logs
-resource "aws_cloudwatch_log_group" "app" {
-  name              = "/ecs/${var.project_name}"
-  retention_in_days = var.log_retention_days
-
-  tags = {
-    Name        = var.project_name
-    Environment = var.environment
-  }
-}
-
-# IAM Roles
-resource "aws_iam_role" "ecs_task_execution" {
-  name = "${var.project_name}-ecs-task-execution-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "ecs-tasks.amazonaws.com"
-      }
-    }]
-  })
-
-  tags = {
-    Name        = "${var.project_name}-ecs-execution-role"
-    Environment = var.environment
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
-  role       = aws_iam_role.ecs_task_execution.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}
-
-resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
-  name = "secrets-access"
-  role = aws_iam_role.ecs_task_execution.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "secretsmanager:GetSecretValue"
-      ]
-      Resource = [
-        aws_secretsmanager_secret.openai_api_key.arn,
-        aws_secretsmanager_secret.pinecone_api_key.arn
-      ]
-    }]
-  })
-}
-
-resource "aws_iam_role" "ecs_task" {
-  name = "${var.project_name}-ecs-task-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "ecs-tasks.amazonaws.com"
-      }
-    }]
-  })
-
-  tags = {
-    Name        = "${var.project_name}-ecs-task-role"
-    Environment = var.environment
-  }
-}
 
 # Application Load Balancer - uncomment all resources below to re-enable ALB
 # Also uncomment: aws_security_group.alb, the ALB ingress in aws_security_group.ecs_tasks,
@@ -367,96 +161,24 @@ resource "aws_iam_role" "ecs_task" {
 #   }
 # }
 
-# ECS Cluster
-resource "aws_ecs_cluster" "main" {
-  name = "${var.project_name}-cluster"
+# Lambda Function
+resource "aws_lambda_function" "app" {
+  function_name = var.project_name
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.app.repository_url}:latest"
+  role          = aws_iam_role.lambda_exec.arn
+  timeout       = 30
+  memory_size   = 512
 
-  setting {
-    name  = "containerInsights"
-    value = "disabled"
-  }
-
-  tags = {
-    Name        = "${var.project_name}-cluster"
-    Environment = var.environment
-  }
-}
-
-resource "aws_ecs_cluster_capacity_providers" "main" {
-  cluster_name = aws_ecs_cluster.main.name
-
-  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
-
-  default_capacity_provider_strategy {
-    base              = 1
-    weight            = 100
-    capacity_provider = "FARGATE"
-  }
-}
-
-# ECS Task Definition
-resource "aws_ecs_task_definition" "app" {
-  family                   = var.project_name
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = var.task_cpu
-  memory                   = var.task_memory
-  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
-  task_role_arn            = aws_iam_role.ecs_task.arn
-
-  container_definitions = jsonencode([{
-    name      = "${var.project_name}-container"
-    image     = "${aws_ecr_repository.app.repository_url}:latest"
-    essential = true
-
-    portMappings = [{
-      containerPort = var.container_port
-      protocol      = "tcp"
-    }]
-
-    environment = [
-      {
-        name  = "PORT"
-        value = tostring(var.container_port)
-      },
-      {
-        name  = "FLASK_ENV"
-        value = var.environment
-      },
-      {
-        name  = "PINECONE_INDEX_NAME"
-        value = "rag-application"
-      }
-    ]
-
-    secrets = [
-      {
-        name      = "OPENAI_API_KEY"
-        valueFrom = aws_secretsmanager_secret.openai_api_key.arn
-      },
-      {
-        name      = "PINECONE_API_KEY"
-        valueFrom = aws_secretsmanager_secret.pinecone_api_key.arn
-      }
-    ]
-
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        "awslogs-group"         = aws_cloudwatch_log_group.app.name
-        "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "ecs"
-      }
+  environment {
+    variables = {
+      FLASK_ENV          = var.environment
+      PINECONE_INDEX_NAME = "rag-application"
     }
+  }
 
-    healthCheck = {
-      command     = ["CMD-SHELL", "python -c \"import requests; requests.get('http://localhost:${var.container_port}/health', timeout=5)\" || exit 1"]
-      interval    = 30
-      timeout     = 10
-      retries     = 3
-      startPeriod = 60
-    }
-  }])
+  # Secrets injected via Secrets Manager at runtime (fetched in app startup)
+  # OPENAI_API_KEY and PINECONE_API_KEY are read from Secrets Manager
 
   tags = {
     Name        = var.project_name
@@ -464,76 +186,98 @@ resource "aws_ecs_task_definition" "app" {
   }
 }
 
-# ECS Service
-resource "aws_ecs_service" "app" {
-  name            = "${var.project_name}-service"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.app.arn
-  desired_count   = var.desired_count
-  launch_type     = "FARGATE"
-
-  network_configuration {
-    security_groups  = [aws_security_group.ecs_tasks.id]
-    subnets          = aws_subnet.public[*].id
-    assign_public_ip = true
-  }
-
-  # load_balancer block - uncomment when re-enabling ALB
-  # load_balancer {
-  #   target_group_arn = aws_lb_target_group.app.arn
-  #   container_name   = "${var.project_name}-container"
-  #   container_port   = var.container_port
-  # }
-  # health_check_grace_period_seconds = 60
-
-  deployment_maximum_percent        = 200
-  deployment_minimum_healthy_percent = 100
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.project_name}"
+  retention_in_days = var.log_retention_days
 
   tags = {
-    Name        = "${var.project_name}-service"
+    Name        = var.project_name
     Environment = var.environment
   }
 }
 
-# Auto Scaling
-resource "aws_appautoscaling_target" "ecs" {
-  max_capacity       = var.max_capacity
-  min_capacity       = var.min_capacity
-  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.app.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  service_namespace  = "ecs"
-}
+# IAM Role for Lambda
+resource "aws_iam_role" "lambda_exec" {
+  name = "${var.project_name}-lambda-exec-role"
 
-resource "aws_appautoscaling_policy" "ecs_cpu" {
-  name               = "${var.project_name}-cpu-autoscaling"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
 
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value       = 70.0
-    scale_in_cooldown  = 300
-    scale_out_cooldown = 60
+  tags = {
+    Name        = "${var.project_name}-lambda-exec-role"
+    Environment = var.environment
   }
 }
 
-resource "aws_appautoscaling_policy" "ecs_memory" {
-  name               = "${var.project_name}-memory-autoscaling"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
 
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
-    }
-    target_value       = 80.0
-    scale_in_cooldown  = 300
-    scale_out_cooldown = 60
+resource "aws_iam_role_policy" "lambda_secrets" {
+  name = "secrets-access"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["secretsmanager:GetSecretValue"]
+      Resource = [
+        aws_secretsmanager_secret.openai_api_key.arn,
+        aws_secretsmanager_secret.pinecone_api_key.arn
+      ]
+    }]
+  })
+}
+
+# API Gateway (HTTP API - cheaper than REST API)
+resource "aws_apigatewayv2_api" "app" {
+  name          = "${var.project_name}-api"
+  protocol_type = "HTTP"
+
+  tags = {
+    Name        = "${var.project_name}-api"
+    Environment = var.environment
   }
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id             = aws_apigatewayv2_api.app.id
+  integration_type   = "AWS_PROXY"
+  integration_uri    = aws_lambda_function.app.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.app.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.app.id
+  name        = "$default"
+  auto_deploy = true
+
+  tags = {
+    Name        = "${var.project_name}-stage"
+    Environment = var.environment
+  }
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.app.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.app.execution_arn}/*/*"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,30 +3,19 @@ output "ecr_repository_url" {
   value       = aws_ecr_repository.app.repository_url
 }
 
-# ALB outputs - uncomment when re-enabling ALB
-# output "alb_dns_name" {
-#   description = "DNS name of the Application Load Balancer"
-#   value       = aws_lb.main.dns_name
-# }
-#
-# output "alb_url" {
-#   description = "Full URL of the Application Load Balancer"
-#   value       = "http://${aws_lb.main.dns_name}"
-# }
-
-output "ecs_cluster_name" {
-  description = "Name of the ECS cluster"
-  value       = aws_ecs_cluster.main.name
+output "lambda_function_name" {
+  description = "Name of the Lambda function"
+  value       = aws_lambda_function.app.function_name
 }
 
-output "ecs_service_name" {
-  description = "Name of the ECS service"
-  value       = aws_ecs_service.app.name
+output "api_gateway_url" {
+  description = "URL of the API Gateway endpoint"
+  value       = aws_apigatewayv2_stage.default.invoke_url
 }
 
 output "cloudwatch_log_group" {
   description = "CloudWatch log group name"
-  value       = aws_cloudwatch_log_group.app.name
+  value       = aws_cloudwatch_log_group.lambda.name
 }
 
 output "secret_arn" {
@@ -34,12 +23,3 @@ output "secret_arn" {
   value       = aws_secretsmanager_secret.openai_api_key.arn
 }
 
-output "vpc_id" {
-  description = "ID of the VPC"
-  value       = aws_vpc.main.id
-}
-
-output "public_subnet_ids" {
-  description = "IDs of public subnets"
-  value       = aws_subnet.public[*].id
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,51 +22,8 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "container_port" {
-  description = "Port exposed by the container"
-  type        = number
-  default     = 3001
-}
-
-variable "task_cpu" {
-  description = "Fargate task CPU units"
-  type        = string
-  default     = "512" # 0.5 vCPU
-}
-
-variable "task_memory" {
-  description = "Fargate task memory in MB"
-  type        = string
-  default     = "1024" # 1 GB
-}
-
-variable "desired_count" {
-  description = "Desired number of ECS tasks"
-  type        = number
-  default     = 1
-}
-
-variable "min_capacity" {
-  description = "Minimum number of tasks for auto scaling"
-  type        = number
-  default     = 1
-}
-
-variable "max_capacity" {
-  description = "Maximum number of tasks for auto scaling"
-  type        = number
-  default     = 1
-}
-
 variable "log_retention_days" {
   description = "CloudWatch Logs retention in days"
   type        = number
   default     = 7
 }
-
-# Optional: For HTTPS
-# variable "certificate_arn" {
-#   description = "ARN of ACM certificate for HTTPS"
-#   type        = string
-#   default     = ""
-# }


### PR DESCRIPTION
## Summary

- **Replace ECS with Lambda** — container image deployed to Lambda instead of ECS Fargate, eliminating the ~$15/mo always-on cost
- **Add API Gateway HTTP API** — routes all requests to Lambda, provides a stable HTTPS endpoint
- **Remove VPC/networking** — Lambda calls Pinecone and OpenAI over the public internet, no VPC, subnets, or security groups needed
- **Secrets bootstrapping** — `app.py` fetches `OPENAI_API_KEY` and `PINECONE_API_KEY` from Secrets Manager on cold start, no-op if already in environment (local dev via `.env` still works)
- **Split requirements** — `requirements.txt` is now Lambda-only (lean); `requirements-ingest.txt` includes heavy deps (`sentence-transformers`, `unstructured`, etc.) for local ingestion scripts
- **Optional reranker** — `sentence-transformers` removed from runtime requirements; `retrieval.py` guards the import and raises a clear `ImportError` if reranking is requested without it installed

## Cost impact

| | Before (ECS Fargate) | After (Lambda) |
|---|---|---|
| Idle cost | ~$15/mo | ~$0/mo |
| Per request | included | ~$0.000001 |

## Test plan

- [ ] Build Docker image locally: `docker build --platform linux/amd64 -t rag-app .`
- [ ] `terraform init && terraform plan` — verify no errors
- [ ] `terraform apply` — deploy Lambda + API Gateway
- [ ] Set secrets: `aws secretsmanager put-secret-value --secret-id rag-application/openai-api-key --secret-string "..."`
- [ ] Push image to ECR and update Lambda
- [ ] Test health endpoint: `curl <api_gateway_url>/health`
- [ ] Test query endpoint: `curl -X POST <api_gateway_url>/query -d '{"query":"What is NVIDIA revenue?","dataset":"sec"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)